### PR TITLE
exclude logged-in user from profile list

### DIFF
--- a/src/pages/profiles/ProfileList.js
+++ b/src/pages/profiles/ProfileList.js
@@ -6,32 +6,42 @@ import Asset from "../../components/Asset";
 import { useProfileData } from "../../contexts/ProfileDataContext";
 import Profile from "./Profile";
 import { Link } from "react-router-dom/cjs/react-router-dom.min";
+import { useCurrentUser } from "../../contexts/CurrentUserContext";
 
 /**
  * Render the list of profiles from most to least recently updated
  */
 const ProfileList = () => {
   const { profileList } = useProfileData();
+  const currentUser = useCurrentUser();
 
   return (
-    <Container className={appStyles.Content}>
-      {/* if profiles are loaded, render them using the Profile component */}
-      {profileList.results.length ? (
-        <>
-          <Link className="align-self-center" to={`/team`}>
-            <h3>
-              <i class="fa-solid fa-users-line"></i>Teammates
-            </h3>
-          </Link>
-          {profileList.results.map((profile) => (
-            <Profile key={profile.id} profile={profile} />
-          ))}
-        </>
-      ) : (
-        // indicate if component is still loading
-        <Asset spinner />
-      )}
-    </Container>
+    // only render the component if a user is logged in
+    currentUser && (
+      <Container className={appStyles.Content}>
+        {/* if profiles are loaded, render them using the Profile component */}
+        {profileList.results.length ? (
+          <>
+            <Link className="align-self-center" to={`/team`}>
+              <h3>
+                <i class="fa-solid fa-users-line"></i>Teammates
+              </h3>
+            </Link>
+            {/* list of users excluding the logged-in user */}
+            {profileList.results.map(
+              (profile) =>
+                profile &&
+                Number(profile.id) !== Number(currentUser.pk) && (
+                  <Profile key={profile.id} profile={profile} />
+                )
+            )}
+          </>
+        ) : (
+          // indicate if component is still loading
+          <Asset spinner />
+        )}
+      </Container>
+    )
   );
 };
 


### PR DESCRIPTION
Only list users under **Teammates** that are not the current user by comparing the `pk` of `currentUser` to the `id` of each `profile` within the map.

> [!IMPORTANT]  
> Since a profile is created each time a user registers, the primary key of these models will be the same for the same user. However, the relevant field is called `pk` in the `User` model (Allauth default) and `id` in the `Profile` model (custom written model).

Do not show the list of Teammates to Visitors who are not logged in.

> [!CAUTION]  
> Deciding to change this  means the conditional inside the map has to be re-written to account for `currentUser` not existing.

Deployed feature branch on Heroku, and manually tested all functionalities.